### PR TITLE
remove mastering django from videos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,9 +287,6 @@ _Django 1.11_
 
 ### Free Videos
 
-_Django 2.2_
-- [Mastering Django](https://www.youtube.com/channel/UCiuZer2ELlG3dAhWCzwz9Og/featured)
-
 _Django 2.1_
 
 - [Django Authentication Tutorial by Vitor Freitas](https://youtu.be/60GTvKCuam8?list=PLLxk3TkuAYnryu1lEcFaBr358IynT7l7H)


### PR DESCRIPTION
In the videos Section, Mastering Django for django 2.2 is not a valid youtube series.
Removed it form README.md