### PR TITLE
:sparkles: Updates new location and adds four useful libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-test-plus](https://github.com/revsys/django-test-plus/) - Useful additions to Django's default TestCase
 - [easy-thumbnails](https://github.com/SmileyChris/easy-thumbnails) - Image thumbnails for Django
 - [django-vanilla-views](https://github.com/tomchristie/django-vanilla-views) - Simpler class-based views in Django
+- [django-waffle](https://github.com/django-waffle/django-waffle) - A feature flipper for Django
 - [django-watson](https://github.com/etianen/django-watson) - Full-text search plugin
 - [factory-boy](https://github.com/FactoryBoy/factory_boy) - Test fixtures replacement
 - [pytest-django](https://github.com/pytest-dev/pytest-django) - Use pytest features in Django

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-allauth](https://github.com/pennersr/django-allauth/) - Improved user registration including social auth
 - [django-autocomplete-light](https://github.com/yourlabs/django-autocomplete-light) - Add autocompletion to forms
 - [django-compressor](https://github.com/django-compressor/django-compressor/) - Compress JavaScript/CSS into a single cached file
+- [django-click](https://github.com/GaretJax/django-click) - Write Django management command using the click CLI library
 - [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms/) - DRY Django forms
 - [dj-database-url](https://github.com/jacobian/dj-database-url) - Database URLs
 - [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar/) - Configurable panels to debug requests/responses

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-guardian](https://github.com/django-guardian/django-guardian) - Per object permissions in Django
 - [django-hijack](https://github.com/arteria/django-hijack) - Admins can log in and work on behalf of other users without having to know their credentials
 - [django-import-export](https://github.com/django-import-export/django-import-export) - Import/export data more easily with admin integration
+- [django-lifecycle](https://github.com/rsinger86/django-lifecycle) - Declarative model lifecycle hooks, inspired by Rails callbacks.
 - [django-loginas](https://github.com/skorokithakis/django-loginas) - "Log in as user" for the Django admin
 - [django-model-utils](https://github.com/jazzband/django-model-utils) - Django model mixins and utilities
 - [django-organizations](https://github.com/bennylope/django-organizations/) - Multi-user accounts for Django projects

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-autocomplete-light](https://github.com/yourlabs/django-autocomplete-light) - Add autocompletion to forms
 - [django-compressor](https://github.com/django-compressor/django-compressor/) - Compress JavaScript/CSS into a single cached file
 - [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms/) - DRY Django forms
-- [dj-database-url](https://github.com/kennethreitz/dj-database-url) - Database URLs
+- [dj-database-url](https://github.com/jacobian/dj-database-url) - Database URLs
 - [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar/) - Configurable panels to debug requests/responses
 - [django-environ](https://github.com/joke2k/django-environ) - Environment variables
 - [django-extensions](https://github.com/django-extensions/django-extensions/) - Custom management extensions, notably `runserver_plus` and `shell_plus`

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-environ](https://github.com/joke2k/django-environ) - Environment variables
 - [django-extensions](https://github.com/django-extensions/django-extensions/) - Custom management extensions, notably `runserver_plus` and `shell_plus`
 - [django-extra-views](https://github.com/AndrewIngram/django-extra-views) - Extra class-based generic views
+- [django-fakery](https://github.com/fcurella/django-fakery) - An easy-to-use implementation of Creation Methods for Django, backed by Faker
 - [django-filter](https://github.com/carltongibson/django-filter) - Powerful filters based on Django QuerySets
 - [django-guardian](https://github.com/django-guardian/django-guardian) - Per object permissions in Django
 - [django-hijack](https://github.com/arteria/django-hijack) - Admins can log in and work on behalf of other users without having to know their credentials


### PR DESCRIPTION
This PR updates the location for dj-database-url which recently moved.

I also added a few libraries which are super useful:

- django-click
- django-fakery
- django-lifecycle
- django-waffle

Cheers :tada: 
