### PR TITLE
Added django-model-field-meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-phonenumber-field](https://github.com/stefanfoulis/django-phonenumber-field) - Model/form field for normalized phone numbers
 - [django-taggit](https://github.com/jazzband/django-taggit/) - Simple model tags
 - [django-reversion](https://github.com/etianen/django-reversion) - Version control for model instances
+- [django-model-field-meta](https://github.com/melvinkcx/django-model-field-meta) - Model field metadata
 
 ### Search
 - [django-haystack](https://github.com/django-haystack/django-haystack) - Modular search for Django


### PR DESCRIPTION
In one of my Django projects, we needed to supply extra information about our model fields. For the purpose, help_text is too limited. Using code comments is not feasible as I need to use those information programatically. Hence, django_model_field_meta package is created.


