### PR TITLE
Include django-clite, a CLI for Django projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ _Django 1.11_
 - [wemake-django-template](https://github.com/wemake-services/wemake-django-template/) - Bleeding edge Django template focused on code quality and security.
 - [django2-project-template](https://github.com/vigo/django2-project-template/) - A quick starter template with PostgreSQL.
 - [django-webpack-starter](https://github.com/khadegd/django-webpack-starter) - Django Webpack starter template for using Webpack 4.
+- [django-clite](https://github.com/oleoneto/django-clite) - A CLI tool to help create and manage Django projects.
 
 ### Open Source
 - [Blog app with users and forms](https://github.com/wsvincent/djangoforbeginners/tree/master/ch7-blog-app-with-users/)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-extensions](https://github.com/django-extensions/django-extensions/) - Custom management extensions, notably `runserver_plus` and `shell_plus`
 - [django-click](https://github.com/GaretJax/django-click) - Write Django management commands using the click CLI library
 - [django-dbbackup](https://github.com/django-dbbackup/django-dbbackup) - Management commands to help backup and restore your project database and media files
+- [django-clite](https://github.com/oleoneto/django-clite) - A CLI tool to help create and manage Django projects.
 
 ### Content Management Systems
 - [wagtail](https://github.com/wagtail/wagtail) - Popular Django content management system (CMS)
@@ -297,7 +298,6 @@ _Django 1.11_
 - [wemake-django-template](https://github.com/wemake-services/wemake-django-template/) - Bleeding edge Django template focused on code quality and security.
 - [django2-project-template](https://github.com/vigo/django2-project-template/) - A quick starter template with PostgreSQL.
 - [django-webpack-starter](https://github.com/khadegd/django-webpack-starter) - Django Webpack starter template for using Webpack 4.
-- [django-clite](https://github.com/oleoneto/django-clite) - A CLI tool to help create and manage Django projects.
 
 ### Open Source
 - [Blog app with users and forms](https://github.com/wsvincent/djangoforbeginners/tree/master/ch7-blog-app-with-users/)


### PR DESCRIPTION
This is a CLI tool built to help manage Django projects. It can automate lots of repetitive tasks like generating new models, test cases, working with DRF. It also does add some other miscellaneous features like configuring the project to run on Docker, exporting environment variables into example environment files and more.

Here's a link to the [documentation](https://github.com/oleoneto/django-clite/blob/master/docs/cli/readme.ipynb).

Hope you find it useful as much as I do.
Cheers!