### PR TITLE
Adding django-query-profiler to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-silk](https://github.com/jazzband/django-silk) - Live profiling and inspection of HTTP requests and database queries
 - [django-waffle](https://github.com/django-waffle/django-waffle) - A feature flipper for Django
 - [model-bakery](https://github.com/model-bakers/model_bakery) - Object factory for Django (rename of legacy Model Mommy project)
+- [django-query-profiler](https://github.com/django-query-profiler/django-query-profiler) - Finds and resolve N+1 queries.  Proposes select_related or prefetch_related for reducing query load
 
 ### Users
 - [django-allauth](https://github.com/pennersr/django-allauth/) - Improved user registration including social auth


### PR DESCRIPTION
This is a query profiler for Django applications, for helping developers answer the question "My Django code/page/API is slow, How do I find out why?"

Below are some of the features of the profiler:

1. Shows code paths making N+1 sql calls: Shows the sql with stack_trace which is making N+1 calls, along with sql count
2. Shows the proposed solution: If the solution to reduce sql is to simply apply a select_related or a prefetch_related, this is highlighted as a suggestion
3. Shows exact sql duplicates: Count of the queries where (sql, parameters) is exactly the same. This is the kind of sql where implementing a query cache would help
4. Flame Graph visualisation: Collects all the stack traces together to allow quickly identifying which area(s) of code is causing the load to the database
5. Command line or chrome plugin: The profiler can be called from command line via context manager, or can be invoked via a middleware, and output shown in a chrome plugin
6. Super easy to configure in any application: The only changes are in settings.py file and in urls.py file


More details on the github repo and readthedocs

[github](https://github.com/django-query-profiler/django-query-profiler)
[pypi](https://pypi.org/project/django-query-profiler/)
[readthedocs](https://django-query-profiler.readthedocs.io/en/latest/index.html)