### PR TITLE
Add celery task queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-q](https://github.com/Koed00/django-q) - A multiprocessing distributed task queue
 - [django-rq](https://github.com/rq/django-rq) - Integration for Redis Queue
 - [django-redis](https://github.com/niwinz/django-redis) - Full featured Redis cache backend for Django
+- [celery](https://github.com/celery/celery) - Robust and broker-agnostic task queues for bigger, performance-focused projects
 
 ### Testing
 - [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar/) - Configurable panels to debug requests/responses


### PR DESCRIPTION
Hey - thanks for providing this amazing list. It is one of the most helpful resources anyone could find about Django. I noticed though that celery is not mentioned - it is assumed being the standard provider so I thought I would add it.