### PR TITLE
Add Django-stronghold

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-braces](https://github.com/brack3t/django-braces) - Reusable, generic mixins
 - [django-extra-views](https://github.com/AndrewIngram/django-extra-views) - Extra class-based generic views
 - [django-vanilla-views](https://github.com/tomchristie/django-vanilla-views) - Simpler class-based views in Django
+- [django-stronghold](https://github.com/mgrouchy/django-stronghold) - Makes all your Django views default login_required
 
 ## Python Packages
 


### PR DESCRIPTION
Stronghold is a very small and easy to use django app that makes all your Django project default to require login for all of your views.

Not sure if this justifies a new category `Auth`.