### PR TITLE
add cookiecutter-vue-django

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ _Django 1.11_
 - [django-webpack-starter](https://github.com/khadegd/django-webpack-starter) - Django Webpack starter template for using Webpack 4.
 - [sos-django-template](https://github.com/erayerdin/sos-django-template) - Django starter template with separate dev and production settings.
 - [django-docker-heroku-template](https://github.com/bfirsh/django-docker-heroku-template) - A template with Docker, GitHub Actions, and Heroku set up for dev/test/prod, plus various other best practices.
-- [cookiecutter-vue-django](https://github.com/ilikerobots/cookiecutter-vue-djano) - Django + Vue starter project fusing Vue SFCs & Django Templates 
+- [cookiecutter-vue-django](https://github.com/ilikerobots/cookiecutter-vue-djano) - Django + Vue starter project fusing Vue SFCs & Django Templates.
 
 ### Open Source Projects
 - [Blog app with users and forms](https://github.com/wsvincent/djangoforbeginners/tree/master/ch7-blog-app-with-users/)

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ _Django 1.11_
 - [django-webpack-starter](https://github.com/khadegd/django-webpack-starter) - Django Webpack starter template for using Webpack 4.
 - [sos-django-template](https://github.com/erayerdin/sos-django-template) - Django starter template with separate dev and production settings.
 - [django-docker-heroku-template](https://github.com/bfirsh/django-docker-heroku-template) - A template with Docker, GitHub Actions, and Heroku set up for dev/test/prod, plus various other best practices.
+- [cookiecutter-vue-django](https://github.com/ilikerobots/cookiecutter-vue-djano) - Django + Vue starter project fusing Vue SFCs & Django Templates 
 
 ### Open Source Projects
 - [Blog app with users and forms](https://github.com/wsvincent/djangoforbeginners/tree/master/ch7-blog-app-with-users/)


### PR DESCRIPTION
This cookiecutter extends the awesome pydanny one, but adds Vue support in a unique way that allows mixed usage of Django Templates and Vue Single File Components (SFCs).  An easy way to bootstrap a flexible Vue + Django project.

Disclaimer: my own repo.  