### PR TITLE
Add Acra to Security category

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 ### Security
 - [django-csp](https://github.com/mozilla/django-csp) - Adds [Content-Security-Policy](http://www.w3.org/TR/CSP/) headers to Django.
 - [django-feature-policy](https://github.com/adamchainz/django-feature-policy) - Set the draft security HTTP header `Feature-Policy` on a Django app.
+- [acra](https://github.com/cossacklabs/acra) - SQL database security suite: proxy for data protection with transparent "on the fly" data encryption, SQL firewall (SQL injections prevention), intrusion detection system; has ready-to-use bindings and examples for Django-apps.
 
 ### Static Assets
 - [django-storages](https://github.com/jschneier/django-storages) - A single library to support multiple custom storage backends for Django.


### PR DESCRIPTION
Acra is a database security proxy that helps developer to encrypt data before storing in the database ("transparent field level encryption"). Acra has [numerous](https://github.com/cossacklabs/acra-engineering-demo/#examples-1-2-protecting-data-on-django-based-web-site) [examples](https://dev.to/cossacklabs/how-to-encrypt-database-fields-transparently-for-your-app-using-acra-and-digitalocean-managed-postgresql-48ce) for Django-based apps.