### PR TITLE
Editors category created + some packages added to Python Packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ _A short list of Python packages that work well with Django._
 - [bleach](https://github.com/mozilla/bleach) - Sanitize your inputs/forms.
 - [black](https://github.com/psf/black) - Uncompromising Python code formatter.
 - [coveragepy](https://github.com/nedbat/coveragepy) - Code coverage measurement.
+- [faker](https://github.com/joke2k/faker) - Faker is a Python package that generates fake data for you.
 - [huey](https://github.com/coleifer/huey) - A little task queue for Python.
 - [nplusone](https://github.com/jmcarp/nplusone) - Auto-detect n+1 queries.
 - [pillow](https://github.com/python-pillow/Pillow) - Python Imaging Library.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Configuration](#configuration)
     - [Content Management Systems](#content-management-systems)
     - [ECommerce](#ecommerce)
+    - [Editors](#editors)
     - [Files/Images](#filesimages)
     - [Forms](#forms)
     - [Logging](#logging)
@@ -123,6 +124,14 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-shop](https://github.com/awesto/django-shop) - Django-based shop system.
 - [shuup](https://github.com/shuup/shuup) - Django E-Commerce Platform.
 - [django-oscar](https://github.com/django-oscar/django-oscar) - Domain-driven e-commerce for Django.
+
+### Editors
+- [django-ckeditor](https://github.com/shaunsephton/django-ckeditor) - Django admin CKEditor integration.
+- [django-markdownx](https://github.com/adi-/django-markdownx) - Comprehensive Markdown plugin built for Django.
+- [django-markdown-editor](https://github.com/agusmakmun/django-markdown-editor) - Awesome Django Markdown Editor, supported for Bootstrap & Semantic-UI.
+- [django-wysiwyg-redactor](https://github.com/douglasmiranda/django-wysiwyg-redactor) - A lightweight wysiwyg editor for Django.
+- [django-business-logic](https://github.com/dgk/django-business-logic) - Visual DSL framework for django.
+- [django-quill-editor](https://github.com/LeeHanYeong/django-quill-editor) - django-quill-editor makes Quill.js easy to use on Django Forms and admin sites.
 
 ### Files/Images
 - [django-cleanup](https://github.com/un1t/django-cleanup) - Zero configuration file/image removal for local and remote files.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ _A short list of Python packages that work well with Django._
 - [nplusone](https://github.com/jmcarp/nplusone) - Auto-detect n+1 queries.
 - [pillow](https://github.com/python-pillow/Pillow) - Python Imaging Library.
 - [pytest](https://github.com/pytest-dev/pytest/) - Testing framework.
+- [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
 - [python-slugify](https://github.com/un33k/python-slugify) - Returns unicode slugs.
 - [sentry-python](https://github.com/getsentry/sentry-python) - Error reporting SDK.
 - [whitenoise](https://github.com/evansd/whitenoise) - Simplified static file serving for Python websites.


### PR DESCRIPTION
I've just created a new section named _Editors_ in order to store all WYSIWYG editors. It includes the following packages. (**These items are the most rated packages in this category**)
- django-ckeditor 
- django-markdownx
- django-markdown-editor
- django-wysiwyg-redactor
- django-business-logic
- django-quill-editor

These packages added to the Python Packages section.
- faker (One of the coolest fake data generators that matches with Django ORM very well)
- python-decouple (A tool to store environment variables for security configurations)