### PR TITLE
Add Django-admin inteface to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-admin-honeypot](https://github.com/dmpayton/django-admin-honeypot) - Configure a honeypot to see who's trying to hack your site.
 - [django-loginas](https://github.com/skorokithakis/django-loginas) - "Log in as user" for the Django admin.
 - [impostor](https://github.com/avallbona/Impostor) - Impostor is a Django application which allows staff members to login as a different user by using their own username and password.
+- [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) - Customize Admin by the admin itself(color, header. title,logo) and  popup windows replaced by modals.
 
 ### APIs
 <!--lint disable double-link-->


### PR DESCRIPTION
Add Django-admin-interface app to the list, enables users to easily customize the admin interface.