### PR TITLE
Add hetzner to IaaS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 </div>
 
 # Awesome Django
-> A curated list of awesome things related to Django.
-Maintained by <a rel="" href="https://github.com/wsvincent">William Vincent</a> and
+> A curated list of awesome things related to Django. Maintained by <a rel="" href="https://github.com/wsvincent">William Vincent</a> and
 <a rel="" href="https://github.com/jefftriplett">Jeff Triplett</a>.
 
 Please consider supporting Django by making a donation to the <a rel="sponsored" href="https://www.djangoproject.com/fundraising/">Django Software Foundation</a>,

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ _Django 2.2_
 - [Digital Ocean](https://www.digitalocean.com)
 - [Linode](https://www.linode.com/)
 - [Amazon Lightsail](https://aws.amazon.com/lightsail/)
+- [Hetzner](https://www.hetzner.com/)
 
 ## Projects
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 </div>
 
 # Awesome Django
-> A curated list of awesome things related to Django. Maintained by <a rel="" href="https://github.com/wsvincent">William Vincent</a> and
-<a rel="" href="https://github.com/jefftriplett">Jeff Triplett</a>.
+> A curated list of awesome things related to Django. Maintained by <a rel="" href="https://github.com/wsvincent">William Vincent</a> and <a rel="" href="https://github.com/jefftriplett">Jeff Triplett</a>.
 
 Please consider supporting Django by making a donation to the <a rel="sponsored" href="https://www.djangoproject.com/fundraising/">Django Software Foundation</a>,
 sponsoring via <a rel="sponsored" href="https://github.com/sponsors/django">GitHub Sponsors</a>,


### PR DESCRIPTION
hetzner is a slightly more cheap and reliable alternative to DigitalOcean, with the servers being based in Europe rather than US