### PR TITLE
Create SEO category and add django-check-seo to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-haystack](https://github.com/django-haystack/django-haystack) - Modular search for Django.
 - [django-watson](https://github.com/etianen/django-watson) - Full-text search plugin.
 
+### Search engine optimisation
+- [django-check-seo](https://github.com/kapt-labs/django-check-seo) - Check SEO of pages.
+
 ### Security
 - [django-csp](https://github.com/mozilla/django-csp) - Adds [Content-Security-Policy](http://www.w3.org/TR/CSP/) headers to Django.
 - [django-feature-policy](https://github.com/adamchainz/django-feature-policy) - Set the draft security HTTP header `Feature-Policy` on a Django app.


### PR DESCRIPTION
SEO is an important aspect of web dev, and many people does not know how it "works", so I think adding a new category is appropriate.

Django Check SEO is a tiny package that will parse the html content of the pages of a Django website, and that will display the list of common mistakes/good practices relative to the content of the page.