### PR TITLE
Add Healthchecks to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ _Django 2.2_
 - [Built with Django](https://builtwithdjango.com) - Curated list of awesome Django projects.
 - [PostHog](https://github.com/PostHog/posthog) - Open-source product analytics.
 - [HyperKitty](https://gitlab.com/mailman/hyperkitty) - A web interface to access GNU Mailman v3 archives.
-- [Healthchecks](https://github.com/healthchecks/healthchecks) - A Cron Monitoring Tool written in Python & Django
+- [Healthchecks](https://github.com/healthchecks/healthchecks) - A Cron Monitoring Tool written in Python & Django.
 
 ## Django REST Framework
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ _Django 2.2_
 - [Built with Django](https://builtwithdjango.com) - Curated list of awesome Django projects.
 - [PostHog](https://github.com/PostHog/posthog) - Open-source product analytics.
 - [HyperKitty](https://gitlab.com/mailman/hyperkitty) - A web interface to access GNU Mailman v3 archives.
+- [Healthchecks](https://github.com/healthchecks/healthchecks) - A Cron Monitoring Tool written in Python & Django
 
 ## Django REST Framework
 


### PR DESCRIPTION
[Healthchecks](https://github.com/healthchecks/healthchecks) is an actively developed open source project based on Django 3.1. Browsing the source is a great way to see an example of a real world Django application, especially for people new to Django as the project is not as complex as something like [Zulip](https://github.com/zulip/zulip).