### PR TITLE
add django-related-admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [impostor](https://github.com/avallbona/Impostor) - Impostor is a Django application which allows staff members to login as a different user by using their own username and password.
 - [django-admin-env-notice](https://github.com/dizballanze/django-admin-env-notice) - Visually distinguish environments in Django Admin, for example: `development`, `staging`, `production`.
 - [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) - Customize Admin by the admin itself(color, header. title,logo) and  popup windows replaced by modals.
+- [django-related-admin](https://github.com/PetrDlouhy/django-related-admin) - A helper library that allows you to write list_displays accross foreign key relationships.
 
 ### APIs
 <!--lint disable double-link-->


### PR DESCRIPTION
Django admin's list_display is a powerful tool for adding columns to a model's admin panel. One weakness is that unlike list_filters, list_display cannot traverse relationships. I.e., given Person has_a Employer, `employer__name` doesn't work in list_display.

django-related-admin enables foreign key attributes in list_display with '__'