### PR TITLE
Add the alwaysdata.com in the PaaS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ _Django 2.2_
 - [Zeit Now](https://zeit.co/home)
 - [Dokku](http://dokku.viewdocs.io/dokku/)
 - [Render](https://render.com/)
+- [alwaysdata](https://www.alwaysdata.com/)
 
 ### IaaS (Infrastructure-as-a-Service)
 - [Digital Ocean](https://www.digitalocean.com)


### PR DESCRIPTION
Hi, this is a suggestion to list alwaysdata.com in the PaaS section. I don't work for them in any way, I'm just a customer there for many years and I'm very pleased with their services around Python/Django.