### PR TITLE
feat: Django celery beat task scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-rq](https://github.com/rq/django-rq) - Integration for Redis Queue.
 - [django-redis](https://github.com/niwinz/django-redis) - Full featured Redis cache backend for Django.
 - [celery](https://github.com/celery/celery) - Robust and broker-agnostic task queues for bigger, performance-focused projects.
+- [django-celery-beat](hhttps://github.com/celery/django-celery-beat) - A periodic task scheduler with database configured by Django's Admin Panel.
 - [django-dramatiq](https://github.com/Bogdanp/django_dramatiq) - Task processing library with a focus on simplicity, reliability and performance.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-rq](https://github.com/rq/django-rq) - Integration for Redis Queue.
 - [django-redis](https://github.com/niwinz/django-redis) - Full featured Redis cache backend for Django.
 - [celery](https://github.com/celery/celery) - Robust and broker-agnostic task queues for bigger, performance-focused projects.
-- [django-celery-beat](hhttps://github.com/celery/django-celery-beat) - A periodic task scheduler with database configured by Django's Admin Panel.
+- [django-celery-beat](https://github.com/celery/django-celery-beat) - A periodic task scheduler with database configured by Django's Admin Panel.
 - [django-dramatiq](https://github.com/Bogdanp/django_dramatiq) - Task processing library with a focus on simplicity, reliability and performance.
 
 ### Testing


### PR DESCRIPTION
This PR includes the link to new "Task Queue" i.e. Django-celery-beat, which helps to schedule task through the admin panel and can be stored in database.