### PR TITLE
Fix Wedge of Django link

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ _Django 3.1_
 - [Django for APIs: Build web APIs with Python and Django](https://djangoforapis.com/)
 - [Django for Professionals: Production websites with Python and Django](https://djangoforprofessionals.com/)
 - [Two Scoops of Django 3.x: Best Practices for the Django Web Framework](https://www.feldroy.com/collections/two-scoops-press/products/two-scoops-of-django-3-x)
-- [A Wedge of Django: Covers Python 3.8 and Django 3.x](https://www.feldroy.com/collections/two-scoops-press/products/django-crash-course)
+- [A Wedge of Django: Covers Python 3.8 and Django 3.x](https://www.feldroy.com/products/a-wedge-of-django)
 
 _Django 3.0_
 - [Speed Up Your Django Tests](https://adamj.eu/tech/2020/05/04/new-book-speed-up-your-django-tests/)


### PR DESCRIPTION
Old link 404'd to old "Django Crash Course" URL.  Fixed to go to new "Wedge of Django" on feldroy.com