### PR TITLE
Add DJ Checkup

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-csp](https://github.com/mozilla/django-csp) - Adds [Content-Security-Policy](http://www.w3.org/TR/CSP/) headers to Django.
 - [django-feature-policy](https://github.com/adamchainz/django-feature-policy) - Set the draft security HTTP header `Feature-Policy` on a Django app.
 - [django-protected-media](https://github.com/cobusc/django-protected-media) - Manages media that are considered sensitive in a protected fashion.
+- [DJ Checkup](https://djcheckup.com) - Runs several checks on your deployed Django site to check for common security mistakes.
 
 ### Static Assets
 - [django-storages](https://github.com/jschneier/django-storages) - A single library to support multiple custom storage backends for Django.


### PR DESCRIPTION
I've been running the DJ Checkup website for the last couple of years and have run close to 6000 security scans over deployed Django websites. I took this over from the Pony Checkup site after Sasha decided to close it down.

In my opinion, this would make a good addition to the Security section. 

Cheers - Stuart.
