### PR TITLE
Add django-nextjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-guardian](https://github.com/django-guardian/django-guardian) - Per object permissions in Django.
 - [django-sql-explorer](https://github.com/groveco/django-sql-explorer) - Share data via SQL queries.
 - [django-tables2](https://github.com/jieter/django-tables2) - HTML tables with pagination/sorting.
+- [django-nextjs](https://github.com/QueraTeam/django-nextjs) - Integrate Next.js with your existing Django project without any hassle.
 
 ### Logging
 - [django-guid](https://github.com/JonasKs/django-guid) - Inject a GUID (Correlation-ID) into every log message in a Django request.


### PR DESCRIPTION
Hi, we at @QueraTeam have developed a solution to use Next.js in our Django codebase, and have been using it in production for a year. We have published this package on PyPI now, and we hope to help anybody who needs to use Next.js without any hassle.

For more information read [this post](https://medium.com/@danialkeimasi/django-next-js-the-easy-way-655efb6d28e1).
