### PR TITLE
Remove Django 2.2 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,8 +365,6 @@ _Django 3.0_
 - [Mastering Django](https://www.amazon.com/Mastering-Django-Nigel-George/dp/0648884414/)
 - [Build a website with Django 3](https://www.amazon.com/Build-Website-Django-Nigel-George/dp/0648884406/)
 
-_Django 2.2_
-- [Tango with Django](https://www.tangowithdjango.com/)
 
 ## Hosting
 


### PR DESCRIPTION
I'm not sure if we should remove this section or just add a warning

Django 2.2 support ended a month ago on April 11, 2022

https://www.djangoproject.com/download/#unsupported-versions

* https://github.com/wsvincent/awesome-django/issues/169