### PR TITLE
Add Flagsmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ _Django 3.0_
 - [PostHog](https://github.com/PostHog/posthog) - Open-source product analytics.
 - [HyperKitty](https://gitlab.com/mailman/hyperkitty) - A web interface to access GNU Mailman v3 archives.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - A Cron Monitoring Tool written in Python & Django.
+- [Flagsmith](https://github.com/Flagsmith/flagsmith) - Open-source Feature Flagging, Remote Config and AB testing.
 
 ## Django REST Framework
 


### PR DESCRIPTION
We're an open source feature flagging platform built on top of Django and Django Rest Framework. Would love to be included in this repo!