### PR TITLE
django-admin-sortable2

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-semantic-admin](https://github.com/globophobe/django-semantic-admin) - Django Semantic UI admin theme.
 - [django-jet-reboot](https://github.com/b1go/django-jet-reboot) - Django Jet is modern template for Django admin interface with improved functionality.
 - [django-baton](https://github.com/otto-torino/django-baton) - A cool, modern and responsive django admin application based on bootstrap 5.
+- [django-admin-sortable2](https://github.com/jrief/django-admin-sortable2) - Generic drag-and-drop ordering for objects in the Django admin interface.
 
 ### APIs
 <!--lint disable double-link-->


### PR DESCRIPTION
[django-admin-sortable2](https://github.com/jrief/django-admin-sortable2) is the most popular sorting library for the Django admin.
531 stars, 120k downloads/month.

Competitors
* [django-admin-sortable](https://github.com/jazzband/django-admin-sortable): 510 stars, 50k downloads/month.
* [django-orderable](https://github.com/django-ordered-model/django-ordered-model): 592 stars, 87k downloads/month.