### PR TITLE
Add dev-case to open source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ _Django 3.2_
 - [HyperKitty](https://gitlab.com/mailman/hyperkitty) - A web interface to access GNU Mailman v3 archives.
 - [Healthchecks](https://github.com/healthchecks/healthchecks) - A Cron Monitoring Tool written in Python & Django.
 - [Flagsmith](https://github.com/Flagsmith/flagsmith) - Open-source Feature Flagging, Remote Config, and AB testing.
+- [Dev-Case](https://github.com/rob32/dev-case) - A django based CMS, Blog and Portfolio.
 
 ## Django REST Framework
 


### PR DESCRIPTION
It would be a great honor for me if [dev-case](https://github.com/rob32/dev-case) makes it into this repo. 