### PR TITLE
Add ReactPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-shapeshifter](https://github.com/kennethlove/django-shapeshifter) - A class-based view to handle multiple forms in one view.
 
 ### Full-stack frameworks
+- [ReactPy](https://github.com/reactive-python/reactpy) - It's React, but in Python. Insert dynamically rendered Python into Django templates using the [ReactPy-Django module](https://github.com/reactive-python/reactpy-django).
 - [Reactor](https://github.com/edelvalle/reactor/) - Phoenix LiveView, but for Django.
 - [Sockpuppet](https://sockpuppet.argpar.se/) - Build reactive applications with the Django tooling you already know and love.
 - [Unicorn](https://www.django-unicorn.com/) - A reactive component framework that progressively enhances a normal Django view, makes AJAX calls in the background, and dynamically updates the DOM.


### PR DESCRIPTION
## Project Information

1. **Project Name:** ReactPy
2. **Project URL:** https://github.com/reactive-python/reactpy
3. **Description:** It's React, but in Python.

Fix #213 

## Criteria

Please answer the following questions about the project you are submitting. This will help us evaluate if the project should be included in the Awesome Django list.

1. **Is the project new?**

- [ ] Yes
- [x] No

2. **How long has the project been maintained?**

3.5 years

3. **How many releases has it had if it's a library or package?**

ReactPy = 93 releases.
ReactPy-Django = 24 releases.

4. **Are you the author or are you submitting the project on behalf of a company?**

- [x] I am the author
- [ ] I am submitting on behalf of a company
- [ ] Other (please specify)

5. **What makes it awesome?**

This is a Python port of ReactJS. We tried to keep the syntax as similar to ReactJS as possible, while still being written in pure Python. All ReactJS design patterns, such as hooks, are replicated identically to their ReactJS counterparts.

## Additional Information

ReactPy is a library for building user interfaces in Python without Javascript. ReactPy interfaces are made from components that look and behave similar to those found in ReactJS.

ReactPy allows you to detach from the traditional MVC architecture that Django forces upon you. This ultimately helps keep things maintainable as a project grows in size.

Additionally, ReactPy uses Django Channels for serving renders to gain significantly higher rendering performance than what Django Core can handle.

ReactPy Django exists as a separate package to provide Django compatibility as well as unique integrations with Django features.

- ReactPy Core Docs: https://reactpy.dev/
- ReactPy Django Docs: https://reactive-python.github.io/reactpy-django/get-started/
- Discord channel: https://discord.gg/uNb5P4hA9X
- GitHub Discussions: https://github.com/reactive-python/reactpy/discussions
