### PR TITLE
Add django-guest-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-improved-user](https://github.com/jambonsw/django-improved-user) - A custom Django user that authenticates via email. Follows identity and authentication best practices.
 - [django-organizations](https://github.com/bennylope/django-organizations/) - Multi-user accounts for Django projects.
 - [django-cas-ng](https://github.com/django-cas-ng/django-cas-ng) - Django-cas-ng is Django CAS (Central Authentication Service) 1.0/2.0/3.0 client library to support SSO (Single Sign On) and Single Logout (SLO).
+- [django-guest-user](https://github.com/julianwachholz/django-guest-user) - Allow visitors to use your site like a regular user and register later.
 
 ### Views
 - [django-braces](https://github.com/brack3t/django-braces) - Reusable, generic mixins.


### PR DESCRIPTION
## Project Information

1. **Project Name:**  `django-guest-user`
2. **Project URL:** https://github.com/julianwachholz/django-guest-user
3. **Description:** Allow visitors to interact with your site like a temporary user ("guest") without requiring registration. They can "convert" to a regular user account at any time without losing data.

## Criteria

Please answer the following questions about the project you are submitting. This will help us evaluate if the project should be included in the Awesome Django list.

1. **Is the project new?**
   - [ ] Yes
   - [x] No

2. **How long has the project been maintained?**
   About two years.

3. **How many releases has it had if it's a library or package?**
   [12 releases so far](https://pypi.org/project/django-guest-user/0.5.5/#history)

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**
   Let visitors interact with your Django application as if they were registered users; at any given point they can choose to "convert" to a proper registered user without losing any work done so far. This package makes this use case easy to implement without having to rely on session data alone, and your existing code doesn't need modifications if you're adding anonymous usage late into the project.

## Additional Information

I created this package as a drop-in replacement for [django-lazysignup](https://github.com/danfairs/django-lazysignup), a more established and better known project which unfortunately hasn't seen any updates or activities by its maintainers since I've started `django-guest-user`. There is also extensive [documentation](https://django-guest-user.readthedocs.io/en/latest/) available.
