### PR TITLE
Add Photon Designer as tutorials source

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ _A short list of Python packages that work well with Django._
 - [Django Girls Tutorial](https://tutorial.djangogirls.org/en/) - Use function-based views to build a blog app.
 - [LearnDjango](https://learndjango.com/) - Tutorials and premium courses on Django and Django REST Framework.
 - [Adam Johnson](https://adamj.eu/tech/) - Adam is on the Technical Board of Django and regularly writes tutorials.
+- [💡 Photon Designer - Django tutorials](https:/photondesigner.com/articles) - Django tutorials by Tom Dekan on how to build Django apps simply - from how to build an instant messenger with Django, add instant search, to using Google Drive as a database. Updated regularly.     
 - [TestDriven](https://testdriven.io/blog/) - Multiple Django-specific tutorials on topics like Docker, payments, and more.
 - [Classy Class-Based Views](https://ccbv.co.uk/) - Detailed descriptions of methods/properties/attributes for each generic class-based view.
 - [Classy Django Forms](https://github.com/ana-balica/classy-django-forms) - Detailed descriptions of methods/properties/attributes for each form class.


### PR DESCRIPTION
---
name: Add Photon Designer as tutorials source
about: Adding a link to Photon Designer as a tutorial in the Awesome Django list
title: "[NEW] Add link to Photon Designer Django tutorials"
labels: new project
assignees: ''
---

## Project Information

1. **Project Name:** Photon Designer tutorials
2. **Project URL:** https://photondesigner.com/articles
3. **Description:** The Photon Designer articles show how to build various Django apps as simply as possible

## Criteria

Please answer the following questions about the project you are submitting. This will help us evaluate if the project should be included in the Awesome Django list.

1. **Is the project new?**
   - [x] Yes
   - [ ] No

2. **How long has the project been maintained?**
11 months

3. **How many releases has it had if it's a library or package?**
   - 

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**
My aim in writing tutorials for Photon Designer is to show how to build various Django apps as simply as possible. I want to show readers how to build Django apps faster and more simply than ever before, including on new topics, such as integrating AI features with Django and new techniques that I've found to build faster.

I publish new Django content weekly to Photon Designer, in the form of written guides and videos. 

Regarding its awesomeness, all the articles have been well received so far with positive upvotes on Reddit, and with multiple guides being featured in Django News and PyCoders weekly.   
