### PR TITLE
Add Django Celery Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-celery-beat](https://github.com/celery/django-celery-beat) - A periodic task scheduler with database configured by Django's Admin Panel.
 - [celery-exporter](https://github.com/danihodovic/celery-exporter) - Prometheus & Grafana monitoring of Celery tasks.
 - [django-dramatiq](https://github.com/Bogdanp/django_dramatiq) - Task processing library with a focus on simplicity, reliability, and performance.
+- [django-celery-results](https://github.com/celery/django-celery-results) -  Celery result backend with Django.
 
 ### Templates
 


### PR DESCRIPTION
## Project Information

1. **Project Name:** django-celery-results

2. **Project URL:** https://github.com/celery/django-celery-results

3. **Description:** This is a package that integrates Celery Results with Django ORM and Django Admin interface.

----

## Criteria

1. **Is the project new?**
   - [ ] Yes
   - [x] No

2. **How long has the project been maintained?**
~7.5 years

3. **How many releases has it had if it's a library or package?**
[12 releases](https://github.com/celery/django-celery-results/releases) & [19 tags](https://github.com/celery/django-celery-results/tags)

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [ ] I am the author
   - [ ] I am submitting on behalf of a company
   - [x] Other (please specify)

Just using it.

5. **What makes it awesome?**

It makes managing and introspecting Celery results easy with Django ORM and Admin integration.