### PR TITLE
Add i18n section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ or buying <a rel="sponsored" href="https://django.threadless.com/">official merc
   - [Forms](#forms)
   - [Full-stack frameworks](#full-stack-frameworks)
   - [General](#general)
+  - [Internationalisation](#i18n)
   - [Logging](#logging)
   - [Model Fields](#model-fields)
   - [Models](#models)
@@ -210,6 +211,13 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-freeze](https://github.com/fabiocaccamo/django-freeze) - Convert your dynamic django site to a static one with one line of code.
 - [django-nh3](https://github.com/marksweb/django-nh3) - Django integration with for nh3 and is an alternative for django-bleach.
 - [Weblate](https://github.com/WeblateOrg/weblate) - Weblate is a copylefted libre software web-based continuous localization system, used by over 2500 libre projects and companies in more than 165 countries.
+
+### <a id="i18n"></a> Internationalisation (i18n)
+
+- [django-localflavor](https://github.com/django/django-localflavor) - A collection of functionality that is useful for particular countries or cultures. Previously a part of the Django core.
+- [django-modeltrans](https://github.com/zostera/django-modeltrans) - Translate Django model fields in a JSONField
+- [django-modeltranslations](https://github.com/deschler/django-modeltranslation) -  Translates Django models using a registration approach.
+- [django-rosetta](https://github.com/mbi/django-rosetta) - Rosetta provides a UI to read and write your project's gettext catalogs within the Django Admin.
 
 ### Logging
 - [django-guid](https://github.com/JonasKs/django-guid) - Inject a GUID (Correlation-ID) into every log message in a Django request.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 ### <a id="i18n"></a> Internationalisation (i18n)
 
 - [django-localflavor](https://github.com/django/django-localflavor) - A collection of functionality that is useful for particular countries or cultures. Previously a part of the Django core.
-- [django-modeltrans](https://github.com/zostera/django-modeltrans) - Translate Django model fields in a JSONField
+- [django-modeltrans](https://github.com/zostera/django-modeltrans) - Translate Django model fields in a JSONField.
 - [django-modeltranslations](https://github.com/deschler/django-modeltranslation) -  Translates Django models using a registration approach.
 - [django-rosetta](https://github.com/mbi/django-rosetta) - Rosetta provides a UI to read and write your project's gettext catalogs within the Django Admin.
 


### PR DESCRIPTION
I noticed there is currently no section that pertains to i18n at all, so as a resident of a country with 4 national languages I felt compelled to add it. :)

I've populated the internationalization category with some of the most commonly used packages that are well established. There are others with many hundreds stars but these projects haven't seen any activity in over 2 years.

- django-localflavor - Self-explanatory as a previous Django core module.
- django-modeltranslations - The i18n project with the most Github stars, using a registry to create migrations and even allows translating third party models.
- django-modeltrans - A modern solution using a single JSONField to store translated values and using virtual fields to access them (my personal favorite as it's much more lightweight and unintrusive than the above)
- django-rosetta - A Web GUI to modify your gettext catalogs

Let me know what you think!