### PR TITLE
feat: Add monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-guid](https://github.com/JonasKs/django-guid) - Inject a GUID (Correlation-ID) into every log message in a Django request.
 - [DRF-API-Logger](https://github.com/vishalanandl177/DRF-API-Logger) - An API Logger for your Django Rest Framework project.
 
+### Monitoring
+- [django-prometheus](https://github.com/korfuri/django-prometheus) - Export Django monitoring metrics to Prometheus.
+- [django-mixin](https://github.com/adinhodovic/django-mixin) - Monitoring mixin for Django-prometheus. A set of Grafana dashboards and Prometheus rules for Django.
+
 ### Model Fields
 - [django-any-urlfield](https://github.com/edoburu/django-any-urlfield) - An improved URL selector to choose between internal models and external URLs.
 - [django-colorfield](https://github.com/fabiocaccamo/django-colorfield) - Color field for django models with a nice color-picker widget.


### PR DESCRIPTION
---
name: Add a new project
about: Suggest a new Django project for the Awesome Django list
title: "[NEW] Project Name"
---

## Project Information

1. **Project Name:** 
Adds a monitoring section with two initial entries:
- Django-prometheus
- Django-mixin
2. **Project URL:** 
https://github.com/korfuri/django-prometheus
https://github.com/adinhodovic/django-mixin
4. **Description:**
   _(Please provide a brief description of the project.)_

Django-prometheus: Export Django monitoring metrics for Prometheus.io

Django-mixin: Monitoring mixin for Django-prometheus. A set of Grafana dashboards and Prometheus rules for Django.

----

## Criteria

Please answer the following questions about the project you are submitting. This will help us evaluate if the project should be included in the Awesome Django list.

1. **Is the project new?**
   - [ ] Yes
   - [x] No

2. **How long has the project been maintained?**
   _(Please provide an approximate duration in months or years.)_
Django-prometheus ~ 5years, django-mixin ~2 years.
3. **How many releases has it had if it's a library or package?**
   _(Please provide the number of releases, or link to the project's release history.)_

https://pypi.org/project/django-prometheus/1.0.11/#history

Mixins usually run alongside git history.

5. **Are you the author or are you submitting the project on behalf of a company?**
   - [x(for django-mixin)] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

6. **What makes it awesome?**
   _(Please provide a brief explanation of why you believe this project is a valuable addition to the Awesome Django list.)_

Django-prometheus adds prometheus metrics to django, supports DB, redis and requests metrics out of the box.

Django-mixin provides out of the box dashboards and alerting rules for the exposed metrics. Tries to standardize and OSS generic alerting rules and dashboards.

In general a monitoring section is needed (where django-prometheus should really be), if a mixin jsonnet library belongs there I'm not sure as all mixins are written in jsonnet (e.g https://github.com/kubernetes-monitoring/kubernetes-mixin). It is not a Django package or Python package.

