### PR TITLE
Adds Django On Remote job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ _A short list of Python packages that work well with Django._
 - [Django News Jobs](https://jobs.django-news.com/) - A Django job board that also aggregates other job boards.
 - [Django Gigs](https://djangogigs.com) - This platform caters specifically to freelance and full-time Django developers. 
 - [Django Jobs](https://djangojobs.net) - Django jobs posting for hiring Django Python developers.
+- [Django On Remote](https://django.on-remote.com/) - Handpicked, remote only Django opportunities
 - [Python.org Job Boards](https://www.python.org/jobs/) - While not exclusively for Django, this job board is hosted by the official Python website and features a range of Python and Django-related job opportunities.
 
 ### Newsletters


### PR DESCRIPTION
It's just a new Django job board I've found. I like that it's remote only.