### PR TITLE
Add Django Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-shapeshifter](https://github.com/kennethlove/django-shapeshifter) - A class-based view to handle multiple forms in one view.
 
 ### Full-stack frameworks
+
+- [Django-Bridge](https://github.com/django-bridge/django-bridge) - The simple way to build React frontends for Django applications.
 - [ReactPy](https://github.com/reactive-python/reactpy) - It's React, but in Python. Insert dynamically rendered Python into Django templates using the [ReactPy-Django module](https://github.com/reactive-python/reactpy-django).
 - [Reactor](https://github.com/edelvalle/reactor/) - Phoenix LiveView, but for Django.
 - [Sockpuppet](https://sockpuppet.argpar.se/) - Build reactive applications with the Django tooling you already know and love.


### PR DESCRIPTION
## Project Information

1. **Project Name:** Django Bridge

2. **Project URL:** https://github.com/django-bridge/django-bridge and https://django-bridge.org/

3. **Description:**
   The simple way to build React frontends for Django applications

----

## Criteria

1. **Is the project new?**
   - [ ] Yes
   - [x] No

2. **How long has the project been maintained?**
   4 years as a closed source project, 6 months as open source

3. **How many releases has it had if it's a library or package?**
   14 as an open source project (including pre-releases)

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**
   It's provides simpler way to build React frontends for Django, which is often overcomplicated when done manually. This library allows you to use regular Django views as a backend for a vanilla, standard React frontend. This gives you the ability to use these two frameworks together with very little overhead.

It's been used to build [SaaS applications](https://wagtail.build/) and internal enterprise applications.