### PR TITLE
Drop the django-ckeditor recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 
 ### Editors
 <!--lint ignore awesome-list-item-->
-- [django-ckeditor](https://github.com/shaunsephton/django-ckeditor) - Django admin CKEditor integration.
 - [django-markdownx](https://github.com/adi-/django-markdownx) - Comprehensive Markdown plugin built for Django.
 - [django-markdown-editor](https://github.com/agusmakmun/django-markdown-editor) - Awesome Django Markdown Editor, supported for Bootstrap & Semantic-UI.
 - [django-business-logic](https://github.com/dgk/django-business-logic) - Visual DSL framework for Django.


### PR DESCRIPTION
django-ckeditor is deprecated and uses CKEditor 4 which has unfixed security issues, it hasn't been a good recommendation for some time.

See the notice at the top of the README  https://github.com/django-ckeditor/django-ckeditor and the pinned issues here https://github.com/django-ckeditor/django-ckeditor/issues

EDIT: Sorry, I should clarify that I have deprecated django-ckeditor and that I have been doing all releases since May 2019. During the last few years I have been the sole active maintainer of the project.