### PR TITLE
added django valkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 ### Caching
 - [django-cachalot](https://github.com/noripyt/django-cachalot) - Caches your Django ORM queries and automatically invalidates them.
 - [django-cacheops](https://github.com/Suor/django-cacheops) - A slick ORM cache with automatic granular event-driven invalidation.
+- [django-redis](https://github.com/niwinz/django-redis) - Full-featured Redis cache backend for Django.
 
 ### Commands
 - [django-extensions](https://github.com/django-extensions/django-extensions/) - Custom management extensions, notably `runserver_plus` and `shell_plus`.
@@ -294,7 +295,6 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [beatserver](https://github.com/rajasimon/beatserver) - A periodic task scheduler for Django.
 - [django-q2](https://github.com/django-q2/django-q2) - A multiprocessing distributed task queue for Django.
 - [django-rq](https://github.com/rq/django-rq) - Integration for Redis Queue.
-- [django-redis](https://github.com/niwinz/django-redis) - Full-featured Redis cache backend for Django.
 - [celery](https://github.com/celery/celery) - Robust and broker-agnostic task queues for bigger, performance-focused projects.
 - [flower](https://github.com/mher/flower) - Flower is a web-based tool for monitoring and administrating Celery clusters.
 - [django-celery-beat](https://github.com/celery/django-celery-beat) - A periodic task scheduler with database configured by Django's Admin Panel.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-cachalot](https://github.com/noripyt/django-cachalot) - Caches your Django ORM queries and automatically invalidates them.
 - [django-cacheops](https://github.com/Suor/django-cacheops) - A slick ORM cache with automatic granular event-driven invalidation.
 - [django-redis](https://github.com/niwinz/django-redis) - Full-featured Redis cache backend for Django.
+- [django-valkey](https://github.com/amirreza8002/django-valkey) - a Valkey cache and session backend for django
 
 ### Commands
 - [django-extensions](https://github.com/django-extensions/django-extensions/) - Custom management extensions, notably `runserver_plus` and `shell_plus`.


### PR DESCRIPTION
---
name: Add a new project
about: Suggest a new Django project for the Awesome Django list, moved django-redis to caching category
title: "django-valkey"
---

## Project Information

1. **Project Name:**  django-valkey

2. **Project URL:**  [django-valkey](https://github.com/amirreza8002/django-valkey)

3. **Description:**
a valkey cache backend for django.

i also moved django-redis to caching category, since it's a cache backend

----

## Criteria

Please answer the following questions about the project you are submitting. This will help us evaluate if the project should be included in the Awesome Django list.

**Note:** If your project is only a few months old or has under 50 to 100 stars on GitHub, it may NOT meet the criteria for inclusion in the Awesome Django list. We recommend that you promote your project more and then consider a submission at a later date when it has gained more visibility and community support.

1. **Is the project new?**
   - [ x] Yes
   - [ ] No

2. **How long has the project been maintained?**
about a month

3. **How many releases has it had if it's a library or package?**
about 20, but 3 stable ones

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [ x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**
valkey is a free licensed alternative to redis, and there has been greate work on it since it was forked.
django-valkey was forked from django-redis, but ever since has seen some good new/improved features.

----

## Additional Information

Please provide any additional information you believe is relevant to the project or its evaluation for inclusion in the Awesome Django list. This might include information about the project's documentation, test coverage, community support, or any unique features that set it apart from other Django projects.

the documentation is hosted on [readthedocs](https://django-valkey.readthedocs.io/en/latest/).
test coverage is 93%.
there are no contributers yet.
we have both sync and async clients, and other things discussed in documentations and changelogs.



Thank you for your submission!
