### PR TITLE
Add Wagtail events page

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,5 +556,6 @@ _Wagtail, the powerful CMS for modern websites._
 - [Wagtail Source Code](https://github.com/wagtail/wagtail/)
 - [awesome-wagtail](https://github.com/springload/awesome-wagtail)
 - [This week in Wagtail](https://wagtail.org/this-week-in-wagtail/) - A (most) weekly email with updates from the Wagtail core team.
-- [Wagtail Space](https://www.wagtail.space/) - Wagtail CMS events around the world.
+- [Wagtail Space](https://www.wagtail.space/) - Wagtail conferences around the world.
+- [Wagtail events](https://wagtail.org/events/) - Online and in-person Wagtail events.
 <!--lint enable double-link-->


### PR DESCRIPTION
## Project Information

1. **Project Name:** Wagtail events page

2. **Project URL:** https://wagtail.org/events/

3. **Description:**
  The Events page is a recap of all Wagtail events – conferences for Wagtail users, contributor sprints, and online webinars. The Wagtail Space website is only the major conferences.

----

## Criteria

1. **Is the project new?**
   - [ ] Yes
   - [x] No

2. **How long has the project been maintained?**
   _(Please provide an approximate duration in months or years.)_ 10 years

3. **How many releases has it had if it's a library or package?**
   _(Please provide the number of releases, or link to the project's release history.)_ Tens

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [x] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**

The Events page is meant to be evergreen, with both upcoming events, and a history of all major community events.
  