### PR TITLE
add django-zeal

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-silk](https://github.com/jazzband/django-silk) - Live profiling and inspection of HTTP requests and database queries.
 - [py-spy](https://github.com/benfred/py-spy) - Sampling profiler for Python programs.
 - [pyinstrument](https://github.com/joerick/pyinstrument) - Call stack profiler for Python, Django, Flask, FastAPI.
+- [django-zeal](https://github.com/taobojlen/django-zeal) - Detect N+1 queries with user-friendly error messages
 
 ### Permissions
 - [django-role-permissions](https://github.com/vintasoftware/django-role-permissions) - Django app for role-based permissions management.


### PR DESCRIPTION
## Project Information

1. **Project Name:** django-zeal

2. **Project URL:** https://github.com/taobojlen/django-zeal

3. **Description:**
  django-zeal automatically detects N+1s with friendly error messages.

----

## Criteria

1. **Is the project new?**
   - [x] Yes
   - [ ] No

2. **How long has the project been maintained?**
   4-ish months

3. **How many releases has it had if it's a library or package?**
  https://github.com/taobojlen/django-zeal/releases (10)

4. **Are you the author or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

5. **What makes it awesome?**
I spent a while looking for an existing library to do this. Unfortunately, the ones out there were unmaintained, didn't catch all types of N+1, slowed down your app, or were not very user-friendly. I wrote django-zeal to solve these problems!

----

## Additional Information

The project is getting bug reports and PRs from the community, and it's been running for a while on our codebase at my job. I'm excited to see others using it!
