### PR TITLE
Add django-llms-txt to Search Engine Optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 
 ### Search Engine Optimisation
 - [django-check-seo](https://github.com/kapt-labs/django-check-seo) - Check SEO of pages.
+- [django-llms-txt](https://github.com/rapitek/django-llms-txt) - Generate llms.txt files to make your site discoverable by AI assistants.
 
 ### Security
 - [django-csp](https://github.com/mozilla/django-csp) - Adds [Content-Security-Policy](http://www.w3.org/TR/CSP/) headers to Django.


### PR DESCRIPTION
Adds [django-llms-txt](https://github.com/rapitek/django-llms-txt) to the Search Engine Optimisation section.

A Django package that generates [llms.txt](https://llmstxt.org/) files — the open standard for making website content discoverable by AI assistants like ChatGPT, Claude, and Perplexity. Supports settings-based configuration, auto-generation from Django models, dynamic views, and a management command for static file generation.

- Published on PyPI: https://pypi.org/project/django-llms-txt/
- MIT licensed
- Supports Django 4.2+, Python 3.9+