### PR TITLE
Add Scalekit Django OIDC example under Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-organizations](https://github.com/bennylope/django-organizations/) - Multi-user accounts for Django projects.
 - [django-cas-ng](https://github.com/django-cas-ng/django-cas-ng) - Django-cas-ng is Django CAS (Central Authentication Service) 1.0/2.0/3.0 client library to support SSO (Single Sign On) and Single Logout (SLO).
 - [django-guest-user](https://github.com/julianwachholz/django-guest-user) - Allow visitors to use your site like a regular user and register later.
+- [scalekit-django-auth-example](https://github.com/scalekit-inc/scalekit-django-auth-example) - OIDC SSO example with Scalekit for Django (enterprise SSO patterns).
 
 ### Views
 - [django-braces](https://github.com/brack3t/django-braces) - Reusable, generic mixins.


### PR DESCRIPTION
Adds [scalekit-django-auth-example](https://github.com/scalekit-inc/scalekit-django-auth-example) under **Users** alongside other SSO-related entries (e.g. django-cas-ng) for teams implementing enterprise OIDC with Django.