### PR TITLE
Add Python Pro Hub to Educational Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ _A short list of Python packages that work well with Django._
 - [Django Girls Tutorial](https://tutorial.djangogirls.org/en/) - Use function-based views to build a blog app.
 - [LearnDjango](https://learndjango.com/) - Tutorials and premium courses on Django and Django REST Framework.
 - [Adam Johnson](https://adamj.eu/tech/) - Adam is on the Technical Board of Django and regularly writes tutorials.
-- [Photon Designer - Django tutorials](https://photondesigner.com/articles) - Django tutorials by Tom Dekan on how to build Django apps simply - from how to build an instant messenger with Django, add instant search, to using Google Drive as a database. Updated regularly.  
+- [Photon Designer - Django tutorials](https://photondesigner.com/articles) - Django tutorials by Tom Dekan on how to build Django apps simply - from how to build an instant messenger with Django, add instant search, to using Google Drive as a database. Updated regularly.
+- - [Python Pro Hub](https://pythonprohub.com/python-web-development-guide/) - Practical Django tutorials covering setup, models, views, forms, authentication, static files, and deployment for beginners and intermediate developers.
 - [TestDriven](https://testdriven.io/blog/) - Multiple Django-specific tutorials on topics like Docker, payments, and more.
 - [Classy Class-Based Views](https://ccbv.co.uk/) - Detailed descriptions of methods/properties/attributes for each generic class-based view.
 - [Classy Django REST Framework](http://www.cdrf.co) - Detailed descriptions with methods/attributes for DRF class-based views and serializers.


### PR DESCRIPTION
Hi, I'd like to add Python Pro Hub to the Educational section.

URL: https://pythonprohub.com/python-web-development-guide/

The site covers a full Django tutorial series including:
- Project setup and configuration
- Models, views, and URLs
- Django forms and user authentication
- Static files with Whitenoise
- Deployment on Render

170+ original articles published. All content is practical and beginner-friendly. Thank you for considering it.