### PR TITLE
Update Platform.sh to Upsun

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ _Django 5_
 - [Heroku](https://www.heroku.com)
 - [Microsoft Azure](https://azure.microsoft.com/en-us/develop/python/)
 - [Piku](https://github.com/piku/piku)
-- [Platform.sh](https://platform.sh)
+- [Upsun](https://upsun.com)
 - [PythonAnywhere](https://www.pythonanywhere.com)
 - [Railway](https://railway.app)
 - [Render](https://render.com)


### PR DESCRIPTION
Platform.sh has rebranded to Upsun. This PR updates the name and link in the PaaS hosting section to reflect the rebrand.

For reference: https://upsun.com/platform-sh-is-now-upsun/