### PR TITLE
Add djangorestframework-unirate to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [drf-spectacular](https://github.com/tfranzel/drf-spectacular) - Sane and flexible OpenAPI 3 schema generation for Django REST framework.
 - [django-webhook](https://github.com/danihodovic/django-webhook) - A plug-and-play Django app for sending outgoing webhooks on model changes.
 - [strawberry-django](https://github.com/strawberry-graphql/strawberry-django) - Django integration with Strawberry, a GraphQL library designed for modern development
+- [djangorestframework-unirate](https://github.com/UniRate-API/djangorestframework-unirate) - Drop-in DRF views, serializer fields, and an exception handler for live currency exchange rates and conversion, keeping the API key server-side.
 <!--lint enable double-link-->
 
 ### Async


### PR DESCRIPTION
Adds [`djangorestframework-unirate`](https://github.com/UniRate-API/djangorestframework-unirate) to the **APIs** section.

**Why it's awesome:** it's a drop-in Django REST Framework companion for currency exchange rates and conversion — three mountable `APIView`s (`rates/`, `convert/`, `currencies/`), serializer fields (`CurrencyCodeField`, `ConvertedAmountField`), and a DRF exception handler that maps upstream errors to sensible HTTP codes. The API key stays server-side, so it pairs naturally with the `django-money` UniRate exchange backend that already ships in django-money. Published on PyPI, OIDC Trusted Publishing, CI matrix green on Python 3.10–3.13 × Django 4.2–5.2 × DRF 3.15/3.16, 43 tests.

Added at the end of the section per the contribution guidelines (non-alphabetical, first-come-first-serve).

**Disclosure:** I'm affiliated with UniRate — happy to adjust the wording or placement if you'd prefer.
