### PR TITLE
Add Deployment subsection under Hosting with DeployHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ or buying <a rel="sponsored" href="https://django.threadless.com/">official merc
   - [Books](#books)
 - [Hosting](#hosting)
   - [PaaS (Platforms-as-a-Service)](#paas-platforms-as-a-service)
+  - [Deployment](#deployment)
   - [IaaS (Infrastructure-as-a-Service)](#iaas-infrastructure-as-a-service)
 - [Projects](#projects)
   - [Boilerplate](#boilerplate)
@@ -484,6 +485,9 @@ _Django 5_
 - [Railway](https://railway.app)
 - [Render](https://render.com)
 - [Vercel](https://vercel.com/home)
+
+### Deployment
+- [DeployHQ](https://www.deployhq.com)
 
 ### IaaS (Infrastructure-as-a-Service)
 - [Digital Ocean](https://www.digitalocean.com)


### PR DESCRIPTION
Adds [DeployHQ](https://www.deployhq.com) under a new `### Deployment` subsection in `## Hosting`.

DeployHQ is a Git-based deployment tool that pushes code from GitHub, GitLab, or Bitbucket to servers via SSH, SFTP, or S3 — useful for Django projects deployed to VPS/IaaS targets (DigitalOcean, Linode, Hetzner) rather than PaaS. It supports build pipelines (manage.py collectstatic, migrate), zero-downtime deploys, and one-click rollback. A free tier is available (1 project, 10 deploys/day).

Proposing a new `### Deployment` subsection rather than slotting under `### PaaS (Platforms-as-a-Service)` because DeployHQ doesn't host the app — it deploys to wherever the app is hosted. A Deployment subsection sits naturally between PaaS and IaaS and leaves room for future deploy-tool entries.

Happy to drop DeployHQ into the existing PaaS list instead if you'd prefer to keep the section structure flat.

- Project page: https://www.deployhq.com