### PR TITLE
Add Spwig to ECommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [saleor](https://github.com/saleor/saleor) - GraphQL-based Django E-Commerce Platform.
 - [django-oscar](https://github.com/django-oscar/django-oscar) - Domain-driven e-commerce for Django.
 
+- [Spwig](https://github.com/Spwig/commerce) - Self-hosted e-commerce platform with full control over code, data, and customers.
 ### Editors
 <!--lint ignore awesome-list-item-->
 - [django-markdownx](https://github.com/neutronX/django-markdownx) - Comprehensive Markdown plugin built for Django.


### PR DESCRIPTION
Spwig is a self-hosted e-commerce platform designed for merchants and agencies who want full control over their commerce stack. It fits this list as it provides a Django-based alternative to SaaS platforms like Shopify, with extensible components and no recurring fees. I followed the list's conventions by ensuring the entry is concise and placed in the correct section without requiring alphabetical sorting.