### PR TITLE
Add django-orm-lens (Models section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-recurrence](https://github.com/jazzband/django-recurrence) - Utility for working with recurring dates in Django.
 - [django-treenode](https://github.com/fabiocaccamo/django-treenode) - Abstract model/admin for tree-based stuff.
 - [django-auto-prefetch](https://github.com/adamchainz/django-auto-prefetch) - Automatically prefetch foreign key values as needed.
+- [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) - Static analysis for Django models without booting the app. Sidebar tree, ER diagrams, and MCP server for AI coding agents. Zero DB, zero credentials required.
 
 ### Performance
 - [django-perf-rec](https://cur.at/GHUO6cn?m=web) - Keep detailed records of the performance of your Django code.


### PR DESCRIPTION
Adds `django-orm-lens` under `### Models` (alphabetical placement — after `django-auto-prefetch`, before `### Performance`).

**What it is:**
- Static analysis for Django models — VS Code extension, Python CLI, and MCP server for AI coding agents
- Zero database, zero Django boot, zero credentials — parses `models.py` via AST
- 9 MCP tools including `find_relations`, `cascade_preview`, `suggest_indexes`, `signal_graph`, `describe_migration_dependency`
- Regression-tested against 63 real models from Zulip, Saleor, Wagtail, django-CMS

**Links:**
- Repo: https://github.com/FROWNINGdev/django-orm-lens
- PyPI: https://pypi.org/project/django-orm-lens/
- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=frowningdev.django-orm-lens
- MIT License, active maintenance, 8 `good first issue` tickets open

Fits under `Models` because it operates on Django model definitions (parses/analyses `models.py`, `signals.py`, `migrations/*.py`).