### PR TITLE
Add django-orm-lens to Models section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-recurrence](https://github.com/jazzband/django-recurrence) - Utility for working with recurring dates in Django.
 - [django-treenode](https://github.com/fabiocaccamo/django-treenode) - Abstract model/admin for tree-based stuff.
 - [django-auto-prefetch](https://github.com/adamchainz/django-auto-prefetch) - Automatically prefetch foreign key values as needed.
+- [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) - Static analysis for Django models without booting the app. Sidebar tree, ER diagrams, and MCP server for AI coding agents. Zero DB, zero credentials required.
 
 ### Performance
 - [django-perf-rec](https://cur.at/GHUO6cn?m=web) - Keep detailed records of the performance of your Django code.


### PR DESCRIPTION
Adds [FROWNINGdev/django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) to the **Models** section — a static-analysis tool for Django ORM.

## What it does

- **Sidebar tree** in VS Code / VSCodium / Cursor: every app, model, field, relation (FK, M2M, O2O, GFK, `related_name`, `on_delete`)
- **Interactive ER diagram** (Mermaid) — one keystroke from any model
- **N+1 heuristics + missing-index detection** — inline CodeAction quick-fixes for common ORM anti-patterns
- **Cross-layer impact analysis** — "delete this field, here's every view / serializer / template / test that breaks"
- **factory_boy scaffold generator** — one command from a model to a working factory
- **Time-travel schema diff** — diff two git refs, get typed events (Add/Drop/Change/RenameField/Model, PartialUniqueConstraint) as a PR-ready markdown fragment
- **MCP server** for AI agents (Claude Desktop, Cursor, Cline, Continue) — 9 read-only tools

Pure AST parse of `models.py` / `signals.py` / `migrations/` — no DB, no Django boot, no credentials.

## Distribution

- **VS Code Marketplace** — v0.9.0, 5.0 rating (verified publisher)
- **Open VSX** — v0.9.0, verified by Eclipse Foundation
- **PyPI CLI** — `pip install django-orm-lens` (3k+ monthly downloads)
- **MCP Registry** — listed as \`io.github.FROWNINGdev/django-orm-lens\`

## Reason

Django's static-analysis / IDE tooling has a real gap. \`django-zeal\` catches N+1 at runtime, \`django-perf-rec\` records perf at test-time, but there is no static-analysis / IDE-integrated peer that reads \`models.py\` and surfaces ORM structure and hazards without booting the app. This fills that gap and, as a bonus, exposes the same parser to AI coding agents via MCP.

## Contributing rules

- One suggestion per PR
- Added at end of the Models section (which is not alphabetical)
- Reason above