### PR TITLE
:handshake: Add Revel to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ _Django 5_
 - [Django CRM Admin](https://github.com/DjangoCRM/django-crm) - Open source Python CRM built entirely on Django Admin Site.
 - [linkding](https://github.com/sissbruecker/linkding) - Self-hosted bookmark manager that is designed to be minimal, fast, and easy to set up using Docker.
 - [pythonic-news](https://github.com/sebst/pythonic-news) - Hacker News clone.
+- [Revel](https://github.com/letsrevel/revel-backend) - Self-hostable event management and ticketing platform with organizations, questionnaire-based attendee screening, QR check-in, and Stripe payments.
 
 ## Django REST Framework
 


### PR DESCRIPTION
Add Revel, a self-hostable event management and ticketing platform built on Django 5.2 LTS and Django Ninja.

> **Resubmission of #339.** That PR was closed in December 2025 with the note: _"At 6 months old with 58 stars, the project is still quite new—we'd encourage you to resubmit once it has more history and community adoption."_ Taking you up on that invitation. Seven months later:
>
> | | At #339 (Dec 2025) | Today (Jul 2026) |
> |---|---|---|
> | Stars | 58 | 103 |
> | Age | ~6 months | ~13 months |
> | Latest version | v1.13.4 | v1.72.1 |
> | Releases since #339 | — | +126 |
> | Commits since #339 | — | +1,600 |
> | Organisations | 1 | 25 |
> | Users | 20 | 400+ |
>
> If it's still too early, no hard feelings — just tell me what the bar looks like and I'll come back again.

## Project Information

1. **Project Name:** Revel

2. **Project URL:** https://github.com/letsrevel/revel-backend

3. **Description:**

   Self-hostable event management and ticketing platform — the ticketing side of Eventbrite plus the community-building side of Meetup, under an MIT license. Organizations with roles and memberships, paid/free ticketing via Stripe, questionnaire-based attendee screening, QR check-in, venue and seat management, and EU VAT/invoicing handled in-house.

   Live instance: https://letsrevel.io · Public demo (reset nightly): https://demo.letsrevel.io · API docs: https://demo-api.letsrevel.io/api/docs · Documentation: https://docs.letsrevel.io

----

## Criteria

1. **How long has the project been maintained?**

   ~13 months of continuous development. Started in a personal repo in June 2025, moved to the `letsrevel` org in August 2025 (first tag `0.1.0` on 2025-08-11). Development has been sustained rather than front-loaded: 788 commits in the last 90 days alone, with the most recent commit today. It has been running in production at letsrevel.io throughout.

2. **How many releases has it had if it's a library or package?**

   178 tagged releases to date, currently at **v1.72.1** — 126 of them since #339 was closed in December. Full history: https://github.com/letsrevel/revel-backend/releases

   It's an application rather than a library, so releases map to deployments of the hosted instance and to published Docker images (`ghcr.io/letsrevel/revel-backend`) that self-hosters pull.

3. **Are you the author, or are you submitting the project on behalf of a company?**
   - [x] I am the author
   - [ ] I am submitting on behalf of a company
   - [ ] Other (please specify)

4. **What makes it awesome?**

   **It's a substantial, modern Django application people can read.** The list is a bit thin on production Django apps built the way Django is actually written in 2026 — Django Ninja rather than DRF, `mypy --strict` across the whole codebase, UV for dependency management, ruff, and a 90% branch-coverage gate enforced in CI (currently ~92%). For anyone wanting to see what a Ninja-based Django codebase looks like at scale — service layer, per-app exception handlers, Celery patterns, PostGIS — it's a real reference rather than a toy.

   **It solves a problem the incumbents actively won't.** Revel was built for queer, LGBTQ+, and sex-positive communities, who routinely get deplatformed by mainstream ticketing services over content policies. Those communities need attendee *screening* — not just payment collection — so the questionnaire system (with optional LLM-assisted evaluation, manual, or hybrid review) is core rather than a bolt-on. The platform is event-agnostic and works for any group, but that origin drove features you won't find in a generic ticketing app.

   **Genuinely self-hostable, not self-hostable-in-theory.** A companion [infra](https://github.com/letsrevel/infra) repo ships Compose files and an interactive setup wizard; the documented slim tier runs on ~2 vCPU / 4 GB (~5 €/mo) with feature flags to switch off antivirus, Telegram, and the observability stack. The frontend image reads its API URL at runtime, so one prebuilt image targets any backend with no rebuild. Self-hosters pay zero commission and own their data.

   **Some things you don't usually see in an open-source app of this size:** in-house EU VAT calculation with B2B reverse charge and live VIES validation, automated PDF invoicing (WeasyPrint) with race-safe sequential numbering, Apple Wallet pass generation, a Telegram bot with FSM conversation flows, HMAC-signed protected media served through Caddy, and a full LGTM observability stack (Loki/Grafana/Tempo/Prometheus) with PII scrubbing.

----

## AI Disclosure

We love transparent contributions. Using AI is perfectly fine, just let us know.

- [x] Yes, this pull request was generated or assisted by AI.
- [ ] No, this pull request was authored entirely by a human.

_The research and drafting of this PR were AI-assisted; every claim in it was verified against the repo and I stand behind all of them. Same policy applies to the project itself — Revel uses AI-assisted coding but publishes an [AI_USAGE.md](https://github.com/letsrevel/revel-backend/blob/main/AI_USAGE.md) that contributors must follow, and nothing lands in `main` that a human doesn't understand, review, and defend._

----

## Additional Information

- **Tests & typing:** ~92% branch coverage (90% gate enforced in CI), `mypy --strict` clean, ruff format + lint, 1000-line-per-file limit enforced by `make check`.
- **Security posture:** SAST (bandit), `pip-audit` dependency CVE scanning plus license checks, nightly dependency audit, periodic OWASP ZAP passive scans, and a private vulnerability disclosure process. Documented in [SECURITY.md](https://github.com/letsrevel/revel-backend/blob/main/SECURITY.md).
- **Documentation:** maintained at [docs.letsrevel.io](https://docs.letsrevel.io) across all three repos (backend, frontend, infra), including a self-hosting guide, architecture notes, and ADRs.
- **Community:** public [Discord](https://discord.gg/Rnwbzuvxvn), a nightly-reset public demo so people can try it without installing anything, and outside contributors landing PRs. 18 forks.
- **Django version policy:** deliberately on 5.2 LTS rather than 6.x — documented reasoning in the README, upgrading for features or CVEs rather than for novelty.
- **Related repos:** [revel-frontend](https://github.com/letsrevel/revel-frontend) (SvelteKit) and [infra](https://github.com/letsrevel/infra) (Compose, Caddy, observability). Only the backend is proposed for the list, since that's the Django part.

Thank you for your time, and for maintaining this list.
