### PR TITLE
Add django-orm-lens under Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ Standalone tools that help in developing Django projects.
 - [djhtml](https://github.com/rtts/djhtml) - Django/Jinja template indenter.
 - [djlint](https://www.djlint.com/) - Lint & Format HTML Templates.
 
+### Static Analysis
+- [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) - Model-level static analysis: ER diagrams, N+1 detection, schema drift, and blast radius in CI, without a database or Django boot.
+
 ## Python Packages
 
 _A short list of Python packages that work well with Django._


### PR DESCRIPTION
Adds `django-orm-lens` under **Developer Tools**, in a new `### Static Analysis` subsection.

**Why a new subsection:** Developer Tools is described as "Standalone tools that help in developing Django projects" and currently holds only `### Templates` (curlylint, djhtml, djlint) — linters for the template side. This is the code-side equivalent: a standalone tool rather than a package you add to `INSTALLED_APPS`, so it does not belong under Third-Party Packages.

**What it does:** parses `models.py` with the `ast` module — no database connection, no Django boot, no credentials. Produces ER diagrams, cross-function N+1 detection, migration/schema drift and blast-radius reports that can gate a pull request in CI. Ships as a VS Code extension, a Python CLI, and an MCP server.

**Links:** [repo](https://github.com/FROWNINGdev/django-orm-lens) · [PyPI](https://pypi.org/project/django-orm-lens/) · [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=FROWNINGdev.django-orm-lens) · [docs](https://frowningdev.github.io/django-orm-lens/)

MIT licensed, actively maintained, 10 contributors. Already listed on [up-for-grabs.net](https://up-for-grabs.net).

One entry, one line, no other sections touched. The doctoc block was left alone — it does not currently index the Developer Tools section.