### PR TITLE
[NEW] django-testcontainers-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-fakery](https://github.com/fcurella/django-fakery) - An easy-to-use implementation of Creation Methods for Django, backed by Faker.
 - [django-pattern-library](https://github.com/torchbox/django-pattern-library) - Pattern library generator for Django templates, to help testing of UI components.
 - [storybook-django](https://github.com/torchbox/storybook-django) - Develop Django UI components in isolation, with Storybook.
+- [django-testcontainers-plus](https://github.com/WoodyWoodster/django-testcontainers-plus) - Django test runner and pytest plugin that auto-starts Postgres, MySQL, Redis, and S3 from existing settings.
 
 ### URLs
 - [dj-database-url](https://github.com/jazzband/dj-database-url) - Database URLs.


### PR DESCRIPTION
## Project Information

1. **Project Name:** django-testcontainers-plus

2. **Project URL:** https://github.com/WoodyWoodster/django-testcontainers-plus

3. **Description:**
A Django-native integration with Testcontainers that starts PostgreSQL, MySQL, Redis, and S3-compatible services for tests using existing Django DATABASES, CACHES, and STORAGES settings. Supports both manage.py test and pytest.

---

## Criteria

1. **How long has the project been maintained?**

Since November 2025, approximately 9 months, with releases in November, January, March, and August.

2. **How many releases has it had if it's a library or package?**

Six published GitHub releases, from v0.1.2 through v0.1.7:
https://github.com/WoodyWoodster/django-testcontainers-plus/releases

3. **Are you the author, or are you submitting the project on behalf of a company?**

- [x] I am the author
- [ ] I am submitting on behalf of a company
- [ ] Other (please specify)

4. **What makes it awesome?**

It lets Django projects test against real services with less infrastructure configuration. It derives service configuration from existing Django settings and integrates with both Django's built-in test runner and pytest. This can remove the need to maintain a separate Docker Compose test stack.

---

## AI Disclosure

- [x] Yes, this pull request was generated or assisted by AI.
- [ ] No, this pull request was authored entirely by a human.

---

## Additional Information

This PR adds the package to the Testing section.

The project currently has 8 GitHub stars, so it does not yet meet the template's 100-star requirement. I understand if inclusion needs to wait until it meets that threshold.
