### PR TITLE
Add django-ox to Task Queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [django-celery-results](https://github.com/celery/django-celery-results) - Celery result backend with Django.
 - [django-tasks](https://github.com/realOrangeOne/django-tasks) - A reference implementation and backport of background workers and tasks in Django, based on [DEP 14](https://www.djangoproject.com/weblog/2024/may/29/django-enhancement-proposal-14-background-workers/).
 - [huey](https://github.com/coleifer/huey) - A little task queue for Python, with Django support including the new `django.tasks` API.
+- [django-ox](https://github.com/oxpull/django-ox) - Database-backed worker for Django's Tasks framework, with transactional enqueue, retries, recurring tasks, and no broker to run.
 
 ### Templates
 - [django-components](https://github.com/django-components/django-components/) - A way to create simple reusable template components in Django.


### PR DESCRIPTION
Adds django-ox to Task Queues.

Reason: Django 6.0 shipped the Tasks framework with development-only backends, and the docs say production systems need a backend with a worker process and a durable queue. django-ox is that backend using only the database you already run: enqueue is a plain INSERT, so a task enqueued inside transaction.atomic() commits or rolls back together with the business data it belongs to, with no on_commit boilerplate and no broker. At-least-once execution with SKIP LOCKED claiming, retries with backoff and per-attempt tracebacks, cron-style recurring tasks that are multi-worker safe, and graceful drain on SIGTERM. 191 tests on SQLite and PostgreSQL 16, benchmarks and soak/chaos results with raw data in the repo, BSD-3.
