### PR TITLE
Add django-chainsaw-mcp to Static Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Standalone tools that help in developing Django projects.
 - [djlint](https://www.djlint.com/) - Lint & Format HTML Templates.
 
 ### Static Analysis
+- [django-chainsaw-mcp](https://github.com/syrian963/django-chainsaw-mcp) - Static analysis and MCP server for what will hurt: delete cascades, N+1 candidates, whether a destructive migration is safe to ship yet, and querysets that read rows the caller may not own.
 - [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) - Model-level static analysis: ER diagrams, N+1 detection, schema drift, and blast radius in CI, without a database or Django boot.
 
 ## Python Packages


### PR DESCRIPTION
One entry under **Static Analysis**, alphabetically before `django-orm-lens`.

[django-chainsaw-mcp](https://github.com/syrian963/django-chainsaw-mcp) is a static analyser and MCP server for the Django questions that stop a deploy rather than describe a project: what a delete cascades into, whether a destructive migration is safe to ship *yet* or still has code referencing the column, which queryset reads a row the caller may not own, what a `save()` sets off three hops away through signals.

22 checks over the AST and the app registry. Read-only — nothing executes the target application and nothing leaves the machine. MIT, on PyPI, and in the official MCP registry.

It overlaps `django-orm-lens` only on N+1: that one is model-level and boots nothing, this one imports the project so it can use the app registry, which is what makes the tenant-ownership and signal-chain checks possible.

Tested against 18 public Django projects (Wagtail, Saleor, django-oscar, Misago, NetBox, pretix, DefectDojo and others); `docs/tested-against.md` documents the twelve defects they found in the tool and the two checks that have never fired on real code, with their coverage numbers.